### PR TITLE
Updated qubit reuse nb, fixed QAOA

### DIFF
--- a/Quantinuum_automatic_qubit_reuse.ipynb
+++ b/Quantinuum_automatic_qubit_reuse.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# Qubit Reuse Compilation\n",
     "\n",
-    "This notebook contains an overview of how to use the `pyqubit_reuse` package. This package provides a `pytket` compiler pass for applying the compilation strategy for reducing the number of qubits in a quantum circuit as detailed in [Qubit-reuse compilation with mid-circuit measurement and reset](https://arxiv.org/abs/2210.08039) by Matthew DeCross, Eli Chertkov, Megan Kohagen and Michael Foss-Feig.\n",
+    "This notebook contains an overview of how to use the `pyqubit_reuse` package. This package provides a `pytket` compiler pass for applying the compilation strategy for reducing the number of qubits in a quantum circuit as detailed in [Qubit-reuse compilation with mid-circuit measurement and reset](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.13.041057) by Matthew DeCross, Eli Chertkov, Megan Kohagen and Michael Foss-Feig.\n",
     "\n",
     "`pytket` is a python module for interfacing with `TKET`, a quantum computing toolkit and optimisation compiler developed by Quantinuum, and is available through `pip`. `pytket` is open source and documentation and examples can be found in the [pytket examples](https://tket.quantinuum.com/examples/) and in the *examples* folder in the [pytket-quantinuum Github repository](https://github.com/CQCL/pytket-quantinuum).\n",
     "\n",
@@ -42,7 +42,7 @@
    "source": [
     "## How to Cite\n",
     "\n",
-    "If you wish to cite the `pyqubit_reuse` package in any academic publications, we recommend citing our paper [Qubit-reuse compilation with mid-circuit measurement and reset](https://arxiv.org/abs/2210.08039)."
+    "If you wish to cite the `pyqubit_reuse` package in any academic publications, we recommend citing our paper [Qubit-reuse compilation with mid-circuit measurement and reset](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.13.041057)."
    ]
   },
   {
@@ -126,7 +126,7 @@
    "source": [
     "## Simple Example\n",
     "\n",
-    "Most current techniques for circuit optimisation focus on reducing the number of gates in a circuit, often aiming to reduce the number of multi-qubit gates as they are known to be more error-prone. The prevailing logic is that a shorter circuit accumulates less noise and so provides better results. The compilation technique available in this repository instead focuses on reducing the number of qubits, or width, of a circuit. This can help turn a circuit that at first seems infeasible on small near-term devices into one that can be executed. A full explanation of the techniques available can be read in the paper [Qubit-reuse compilation with mid-circuit measurement and reset](https://arxiv.org/abs/2210.08039).\n",
+    "Most current techniques for circuit optimisation focus on reducing the number of gates in a circuit, often aiming to reduce the number of multi-qubit gates as they are known to be more error-prone. The prevailing logic is that a shorter circuit accumulates less noise and so provides better results. The compilation technique available in this repository instead focuses on reducing the number of qubits, or width, of a circuit. This can help turn a circuit that at first seems infeasible on small near-term devices into one that can be executed. A full explanation of the techniques available can be read in the paper [Qubit-reuse compilation with mid-circuit measurement and reset](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.13.041057).\n",
     "\n",
     "Let's first consider how such a technique is possible via a basic example. An existing circuit is downloaded from nexus."
    ]
@@ -422,7 +422,7 @@
     "\n",
     "Lets construct a `QubitReuse` `CompilerPass` object and apply it to our original 3-qubit circuit.\n",
     "\n",
-    "One of the arguments for constructing the `CompilerPass` is a function for ordering. The reuse compilation works by finding causal cones of qubit outputs (See Fig2 in [Qubit-reuse compilation with mid-circuit measurement and reset](https://arxiv.org/abs/2210.08039)) and merging qubits with disjoint causal cones. The order in which these causal cones are merged can effect the number of qubits in the output circuit, with an optimal ordering producing a circuit with a minimum number of qubits.\n",
+    "One of the arguments for constructing the `CompilerPass` is a function for ordering. The reuse compilation works by finding causal cones of qubit outputs (See Fig. 2 in [Qubit-reuse compilation with mid-circuit measurement and reset](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.13.041057)) and implementing all of the gates in a given causal cone before proceeding to other causal cones. The order in which causal cones are chosen for implementation determines how many qubits are required in the output circuit, since causal cones that share many qubits generally require adding fewer new live qubits to a circuit to implement. An optimal ordering of causal cones produces a circuit with a minimum number of qubits.\n",
     "\n",
     "The `OrderingMethod` class provides four options for finding this ordering. For now we will look at the `BruteForceOrder` option."
    ]
@@ -464,7 +464,7 @@
    "source": [
     "As with the case we solved ourselves above, the `QubitReuse` pass is able to reduce the circuit from three to two qubits.\n",
     "\n",
-    "Not let's consider a real algorithm."
+    "Now let's consider a real algorithm."
    ]
   },
   {
@@ -474,21 +474,19 @@
    "source": [
     "## Demonstrating Compilation with Qubit Reuse for QAOA Circuits\n",
     "\n",
-    "Combinatorial optimization problems in quantum computing are defined by $n$ bits and $m$ clauses where each clause is a constraint on a subset of the bits which is either satisfied or unsatisfied for a given bitstring:\n",
-    "\n",
-    "$C(x) = \\sum\\limits_{a=1}^{m}C_a(x)$\n",
-    "\n",
-    "Alternatively, this can be considered as the problem of finding the maximum eigenvalue and its corresponding eigenstates for the following diagonal Hamiltonian:\n",
+    "Combinatorial optimization problems in quantum computing can be considered as the problem of finding the ground state and its energy for a diagonal Hamiltonian on $n$ qubits:\n",
     "\n",
     "$H = \\sum\\limits_{x\\in\\{0,1\\}^{n}}C(x)|x\\rangle\\langle x|$ \n",
     "\n",
     "The paper [A Quantum Approximate Optimisation Algorithim](https://arxiv.org/abs/1411.4028) by Edward Farhi, Jeffrey Goldstone and Sam Gutmann details an algorithm for doing this.\n",
     "\n",
-    "A commonly tackled combinatorial optimization problem is the Max Cut problem: given some graph with $N$ nodes and $E$ edges, split the nodes into two subsets such that there is a maximum number of edges between both subsets. This is equivalent to finding the maximum eigenvalue and corresponding eigenstates for the following Hamiltonian: \n",
+    "A commonly tackled combinatorial optimization problem is the Max Cut problem: given some graph with $N$ nodes and $E$ edges, split the nodes into two subsets such that there is a maximum number of edges between both subsets. This is equivalent to finding the ground state and its energy for the following Hamiltonian: \n",
     "\n",
-    "$H = \\sum\\limits_{(j,k)\\in E} 0.5(1 - Z_jZ_k)$ \n",
+    "$H = -\\sum\\limits_{(j,k)\\in E} 0.5(1 - Z_jZ_k)$ \n",
     "\n",
-    "Lets create a graph and consider an example problem using `networkx`.\n",
+    "Since the first term in parentheses shifts the energy by an overall constant, it can be ignored.\n",
+    "\n",
+    "Let's create a graph and consider an example problem using `networkx`.\n",
     "\n",
     "**Note:** To run this example, run `pip install networkx` in your python environment."
    ]
@@ -515,9 +513,9 @@
    "source": [
     "For this problem, having nodes `1` and `4` in the same subset (i.e. labelled differently to the remaining nodes) gives 6 edges between subsets, the maximum result.\n",
     "\n",
-    "[A Quantum Approximate Optimisation Algorithim](https://arxiv.org/abs/1411.4028) uses a variational algorithim with a paramterised circuit construction to find the maximum eigenvalue and corresponding eigenstates of the encoded Hamiltonian. From here on we will not look at how to solve the problem, but instead take the circuit construction proposed and show how qubit reuse can reduce the number of qubits in the circuit. \n",
+    "[A Quantum Approximate Optimisation Algorithim](https://arxiv.org/abs/1411.4028) uses a variational algorithim with a parameterised circuit construction to find the maximum eigenvalue and corresponding eigenstates of the encoded Hamiltonian. From here on we will not look at how to solve the problem, but instead take the circuit construction proposed and show how qubit reuse can reduce the number of qubits in the circuit. \n",
     "\n",
-    "To do so, we will define two functions, one to convert the edges of a graph to our cost Hamiltonian, represented by the `pytket` `QubitPauliOperator` object, the other to convert the edges of a graph to a `pytket` `Circuit`."
+    "To do so, we will define a function to convert the edges of a graph to a `pytket` QAOA `Circuit`. Technically, qubit reuse could depend on the order in which we insert gates corresponding to edges, but we will not worry about that for this demonstration."
    ]
   },
   {
@@ -528,21 +526,6 @@
    "outputs": [],
    "source": [
     "from typing import List, Tuple\n",
-    "from pytket.utils import QubitPauliOperator, gen_term_sequence_circuit\n",
-    "from pytket.pauli import QubitPauliString, Pauli\n",
-    "from pytket import Qubit\n",
-    "from pytket.passes import DecomposeBoxes\n",
-    "\n",
-    "\n",
-    "def qaoa_graph_to_cost_hamiltonian(edges: List[Tuple[int, int]], \n",
-    "                                   cost_angle: float) -> QubitPauliOperator:\n",
-    "    \"\"\" Convert QAOA graph to cost Hamiltonian. \"\"\"\n",
-    "    qpo_dict = {QubitPauliString(): len(edges) * 0.5 * cost_angle}\n",
-    "    for e in edges:\n",
-    "        term_string = QubitPauliString([Qubit(e[0]), Qubit(e[1])], [Pauli.Z, Pauli.Z])\n",
-    "        qpo_dict[term_string] = -0.5 * cost_angle\n",
-    "    return QubitPauliOperator(qpo_dict)\n",
-    "\n",
     "\n",
     "def gen_qaoa_max_cut_circuit(edges: List[Tuple[int, int]],\n",
     "                             n_nodes: int,\n",
@@ -558,14 +541,13 @@
     "\n",
     "    # add cost and mixer terms to state\n",
     "    for cost, mixer in zip(cost_angles, mixer_angles):\n",
-    "        cost_ham = qaoa_graph_to_cost_hamiltonian(edges, cost)\n",
-    "        mixer_ham = QubitPauliOperator(\n",
-    "            {QubitPauliString([Qubit(i)], [Pauli.X]): mixer for i in range(n_nodes)}\n",
-    "        )\n",
-    "        qaoa_circuit.append(gen_term_sequence_circuit(cost_ham, Circuit(n_nodes)))\n",
-    "        qaoa_circuit.append(gen_term_sequence_circuit(mixer_ham, Circuit(n_nodes)))\n",
     "\n",
-    "    DecomposeBoxes().apply(qaoa_circuit)\n",
+    "        for edge in edges:\n",
+    "            qaoa_circuit.ZZPhase(cost, edge[0], edge[1])\n",
+    "\n",
+    "        for i in range(n_nodes):\n",
+    "            qaoa_circuit.Rx(mixer,i)\n",
+    "\n",
     "    qaoa_circuit.measure_all()\n",
     "    return qaoa_circuit"
    ]
@@ -594,7 +576,7 @@
    "id": "b52ff266",
    "metadata": {},
    "source": [
-    "We've constructed a 7-qubit circuit: an intuitive explanation of the circuit constructed may be that each edge in the graph corresponds to a ZZ term in the Hamiltonian, and each ZZ term in the Hamiltonian corresponds to a ZZ Pauli Gadget in the circuit.\n",
+    "We've constructed a 7-qubit circuit: an intuitive explanation of the circuit constructed may be that each edge in the graph corresponds to a ZZ term in the Hamiltonian, and each ZZ term in the Hamiltonian corresponds to a ZZPhase gate in the circuit.\n",
     "\n",
     "Can qubit reuse reduce this? \n",
     "\n",
@@ -640,9 +622,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "random_11_node_graph = nx.random_regular_graph(4, 11)\n",
+    "random_9_node_graph = nx.random_regular_graph(4, 9)\n",
     "nx.draw(\n",
-    "    random_11_node_graph, labels={node: node for node in random_11_node_graph.nodes()}\n",
+    "    random_9_node_graph, labels={node: node for node in random_9_node_graph.nodes()}\n",
     ")"
    ]
   },
@@ -653,9 +635,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "random_11_node_graph_edges = list(random_11_node_graph.edges())\n",
-    "qaoa_circuit_11 = gen_qaoa_max_cut_circuit(random_11_node_graph_edges, 11, [0.3], [0.3])\n",
-    "render_circuit_jupyter(qaoa_circuit_11)"
+    "random_9_node_graph_edges = list(random_9_node_graph.edges())\n",
+    "qaoa_circuit_9 = gen_qaoa_max_cut_circuit(random_9_node_graph_edges, 9, [0.3], [0.3])\n",
+    "render_circuit_jupyter(qaoa_circuit_9)"
    ]
   },
   {
@@ -665,7 +647,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "compilation_unit = CompilationUnit(qaoa_circuit_11)\n",
+    "compilation_unit = CompilationUnit(qaoa_circuit_9)\n",
     "qubit_reuse_pass.apply(compilation_unit)\n",
     "render_circuit_jupyter(compilation_unit.circuit)"
    ]
@@ -695,7 +677,7 @@
    "source": [
     "## Additional Ordering Methods\n",
     "\n",
-    "Note that all the functions provided below correspond to the techniques outlined in [Qubit-reuse compilation with mid-circuit measurement and reset](https://arxiv.org/abs/2210.08039)."
+    "Note that all the functions provided below correspond to the techniques outlined in [Qubit-reuse compilation with mid-circuit measurement and reset](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.13.041057)."
    ]
   },
   {
@@ -773,7 +755,7 @@
    "id": "da79fb8b",
    "metadata": {},
    "source": [
-    "For between 10 and 25 Qubits you may want to use `OrderingMethod.ConstrainedOptOrder()`. The `ConstrainedOptOrder` function corresponds to the Constraint Optimization method outlined in the paper, which finds the optimal reduced number of qubits. You may not want to use it beyond 25 qubits as it may take the Constraint Optimization solver a long time to find the optimal solution."
+    "The default settings for qubit reuse will use `OrderingMethod.ConstrainedOptOrder()` for qubit numbers between 10 and 25. The `ConstrainedOptOrder` function corresponds to the CP-SAT method outlined in the paper, which finds the optimal reduced number of qubits. The complexity of CP-SAT is highly dependent on circuit structure, so it may or may not take a long time for larger circuits."
    ]
   },
   {
@@ -866,11 +848,11 @@
    "id": "b038d580",
    "metadata": {},
    "source": [
-    "The `QubitReuse` pass has two further parametrisations that can be used. \n",
+    "The `QubitReuse` pass has two further parameters that can be used. \n",
     "\n",
-    "The first is `DualStrat`. Given that some of the available reodering methods are heuristics, sometimes a better solution can be found by running the algorithim on a similar problem that can be easily mapped to a correct solution. In this case, we can run the qubit reuse scheme on the reverse circuit and then reverse it again to get a logically equivalent circuit. \n",
+    "The first is `DualStrat`. Given that some of the available reodering methods are heuristics, sometimes a better solution can be found by running the algorithm on the dual circuit as described in [Qubit-reuse compilation with mid-circuit measurement and reset](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.13.041057). In this case, we can run the qubit reuse scheme on the reverse (dual) circuit and then reverse it again to get a logically equivalent circuit. \n",
     "\n",
-    "`DualStrat` has three options: `Single`, `Dual` and `Auto`. `Single` runs the qubit reuse algorithm on the given circuit only. `Dual` runs the qubit reuse algorithm on the reversed circuit and `Auto` runs on both the given and reversed circuit and returns the circuit with fewer qubits. If both circuits have the same number of qubits it returns the circuit with better depth, defaulting to the `None` strategy if both are deemed equivalent.  By default `Auto` is used.\n",
+    "`DualStrat` has three options: `Single`, `Dual` and `Auto`. `Single` runs the qubit reuse algorithm on the given circuit only. `Dual` runs the qubit reuse algorithm on the reversed circuit and `Auto` runs on both the given and reversed circuit and returns the circuit with fewer qubits. If both circuits have the same number of qubits it returns the circuit with better depth, defaulting to the `None` strategy if both are deemed equivalent.  By default, and for best performance, `Auto` is used. \n",
     "\n",
     "We will look at how to run it using the previous QAOA examples."
    ]
@@ -944,9 +926,9 @@
    "id": "41562b84",
    "metadata": {},
    "source": [
-    "We can see the by specifying a minimum of 11 qubits, the returned circuit is now larger. \n",
+    "We can see that by specifying a minimum of 11 qubits, the returned circuit is now larger. \n",
     "\n",
-    "Finally, in some algorithmic scenarios we may be able to reason that the outcome results of certain qubits are not necessary to the full algorithm being run. For this scenario we provide a method in `pyqubit_reuse` called `correlation_subcircuit` which given a list of `Qubit` and `Bit` that are known to be required, returns a new `Circuit` only containing operations in the causal cones of the `Qubit` and `Bit` given. "
+    "Finally, in some algorithmic scenarios, such as computing few-body correlation functions, we may be able to reason that the outcome results of certain qubits are not necessary to the full algorithm being run. For this scenario we provide a method in `pyqubit_reuse` called `correlation_subcircuit` which given a list of `Qubit` and `Bit` that are known to be required, returns a new `Circuit` only containing operations in the causal cones of the `Qubit` and `Bit` given. "
    ]
   },
   {
@@ -994,7 +976,7 @@
    "id": "afcb0c3c",
    "metadata": {},
    "source": [
-    "As described in [Qubit-reuse compilation with mid-circuit measurement and reset](https://arxiv.org/abs/2210.08039), compilation of tensor network circuits can be improved with qubit-reuse. For instance, for a quantum circuit implementation of the (depth-D, binary, open boundary conditions) Multiscale Entanglement Renormalization Ansatz (MERA, see [A class of quantum many-body states that can be efficiently simulated](https://arxiv.org/pdf/quant-ph/0610099) in detail) defined on $2^D$ qubits, the full output can be measured with only $2D - 1$ qubits."
+    "As described in [Qubit-reuse compilation with mid-circuit measurement and reset](https://journals.aps.org/prx/abstract/10.1103/PhysRevX.13.041057), compilation of tensor network circuits can be improved with qubit-reuse. For instance, for a quantum circuit implementation of the (depth-D, binary, open boundary conditions) Multiscale Entanglement Renormalization Ansatz (MERA, see [A class of quantum many-body states that can be efficiently simulated](https://arxiv.org/pdf/quant-ph/0610099) in detail) defined on $2^D$ qubits, the full output can be measured with only $2D - 1$ qubits."
    ]
   },
   {


### PR DESCRIPTION
Fixed the definition of QAOA circuits.
Updated QAOA description and qubit reuse algorithm descriptions.
Links to qubit reuse paper now point to PRX version.
Typo fixes.